### PR TITLE
Migrate from makeStyles to styled components

### DIFF
--- a/src/components/AliasDesc.jsx
+++ b/src/components/AliasDesc.jsx
@@ -1,18 +1,7 @@
 import { Box, Typography } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { styled } from "@mui/material";
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    display: "flex",
-    flexDirection: "column",
-    marginTop: theme.spacing(1),
-    width: "90%",
-  },
-}));
-
-const AliasDesc = ({ aliases, schedule }) => {
-  const classes = useStyles();
-
+const UnstyledAliasDesc = ({ className, aliases, schedule }) => {
   const aliasMap = (classObj) => {
     const classId = classObj.class;
     if (classId in aliases) {
@@ -24,7 +13,7 @@ const AliasDesc = ({ aliases, schedule }) => {
   };
 
   return (
-    <Box className={classes.root}>
+    <Box className={className}>
       <Typography key="Note" variant="caption">
         Note:
       </Typography>
@@ -36,5 +25,12 @@ const AliasDesc = ({ aliases, schedule }) => {
     </Box>
   );
 };
+
+const AliasDesc = styled(UnstyledAliasDesc)(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  marginTop: theme.spacing(1),
+  width: "90%",
+}));
 
 export default AliasDesc;

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,43 +1,32 @@
 import GitHubIcon from "@mui/icons-material/GitHub";
 import { IconButton } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { styled } from "@mui/material";
 
-const useStyles = makeStyles((theme) => ({
-  footer: {
-    backgroundColor: "#167742",
-    padding: theme.spacing(1),
-    textAlign: "center",
-    align: "center",
-  },
-  iconButton: {
-    padding: "4px",
-  },
-  logo: {
-    maxWidth: 24,
-    padding: "4px",
-  },
-}));
-
-const Footer = () => {
-  const classes = useStyles();
-
+const UnstyledFooter = ({ className }) => {
   return (
-    <footer className={classes.footer}>
+    <footer className={className}>
       <IconButton
+        sx={{ padding: "4px" }}
         aria-label="github-link"
-        className={classes.iconButton}
         href="https://github.com/Exanut/schedubuddy-web"
       >
         <GitHubIcon fontSize="large" />
       </IconButton>
 
       <IconButton
+        sx={{ padding: "4px" }}
         aria-label="github-link"
-        className={classes.iconButton}
         href="https://www.instagram.com/aaarctan/"
       ></IconButton>
     </footer>
   );
 };
+
+const Footer = styled(UnstyledFooter)(({ theme }) => ({
+  backgroundColor: "#167742",
+  padding: theme.spacing(1),
+  textAlign: "center",
+  align: "center",
+}));
 
 export default Footer;

--- a/src/components/FormInputs/MiniSelect.jsx
+++ b/src/components/FormInputs/MiniSelect.jsx
@@ -1,21 +1,12 @@
 import { Grid, InputLabel } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { styled } from "@mui/material";
 import BasicSelect from "./BasicSelect";
 
-const useStyles = makeStyles((theme) => ({
-  label: {
-    color: theme.palette.text.primary,
-    whiteSpace: "normal",
-  },
-}));
-
-const MiniSelect = ({ label, ...rest }) => {
-  const classes = useStyles();
-
+const UnstyledMiniSelect = ({ className, label, ...rest }) => {
   return (
     <Grid container direction="row" justifyContent="space-between" alignItems="center">
       <Grid item xs={12} lg={6}>
-        <InputLabel className={classes.label}>{label}</InputLabel>
+        <InputLabel className={className}>{label}</InputLabel>
       </Grid>
       <Grid item xs={12} lg={4}>
         <BasicSelect {...rest} />
@@ -23,5 +14,10 @@ const MiniSelect = ({ label, ...rest }) => {
     </Grid>
   );
 };
+
+const MiniSelect = styled(UnstyledMiniSelect)(({ theme }) => ({
+  color: theme.palette.text.primary,
+  whiteSpace: "normal",
+}));
 
 export default MiniSelect;

--- a/src/components/FormSwitcher.jsx
+++ b/src/components/FormSwitcher.jsx
@@ -3,7 +3,7 @@ import { TabList } from "@mui/lab";
 import { styled } from "@mui/material";
 import Tab from "@mui/material/Tab";
 
-function UnstyledFormSwitcher({ className, onChange }) {
+const UnstyledFormSwitcher = ({ className, onChange }) => {
   return (
     <TabList
       aria-label="Schedule tools"
@@ -27,7 +27,7 @@ function UnstyledFormSwitcher({ className, onChange }) {
       />
     </TabList>
   );
-}
+};
 
 const FormSwitcher = styled(UnstyledFormSwitcher)(({ theme }) => ({
   marginBottom: theme.spacing(1),

--- a/src/components/Schedule.jsx
+++ b/src/components/Schedule.jsx
@@ -1,14 +1,4 @@
-import { makeStyles } from "@mui/styles";
 import { createRef, useEffect, useState } from "react";
-
-const useStyles = makeStyles({
-  Media: {
-    height: "auto",
-    width: "auto",
-    maxHeight: "90%",
-    maxWidth: "90%",
-  },
-});
 
 const leftMarginOffset = 148;
 const topMarginOffset = 90;
@@ -135,7 +125,7 @@ const drawSchedule = (
   let max_y = -2147483648;
 
   // Define a courseId to color mapping
-  const uniqueCourseOrder = [...new Set(courseOrder)]
+  const uniqueCourseOrder = [...new Set(courseOrder)];
   let courseColorMap = uniqueCourseOrder.reduce((colorMap, courseId, i) => {
     colorMap[courseId] = colorOrder[i % colorOrder.length];
     return colorMap;
@@ -250,7 +240,6 @@ const convertCanvasToImage = () => {
 };
 
 const Schedule = ({ courseOrder, jsonSched, aliases, showInstructorNames }) => {
-  const classes = useStyles();
   const canvas = createRef(null);
   const [image, setImage] = useState(null);
   const [dataURL, setDataURL] = useState("");
@@ -285,8 +274,13 @@ const Schedule = ({ courseOrder, jsonSched, aliases, showInstructorNames }) => {
     <>
       <img
         src={dataURL}
-        className={classes.Media}
-        style={{ visibility: dataURL ? "visible" : "hidden" }}
+        style={{
+          height: "auto",
+          width: "auto",
+          maxHeight: "90%",
+          maxWidth: "90%",
+          visibility: dataURL ? "visible" : "hidden",
+        }}
         alt="schedule"
       ></img>
       <canvas hidden id="canvas" ref={canvas}></canvas>

--- a/src/forms/Room.jsx
+++ b/src/forms/Room.jsx
@@ -1,5 +1,4 @@
 import { Autocomplete, Button, TextField } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 import { Stack } from "@mui/system";
 import BasicSelect from "components/FormInputs/BasicSelect";
 import { useFormContext } from "context/Form";
@@ -7,15 +6,7 @@ import { useState } from "react";
 
 const API_URL = process.env.REACT_APP_API_URL;
 
-const useStyles = makeStyles((theme) => ({
-  buttonContainer: {
-    textAlign: "center",
-  },
-}));
-
 export const Form = (props) => {
-  const classes = useStyles();
-
   const { values, handleChange, setValues } = useFormContext();
   const [roomOptions, setRoomOptions] = useState([]);
 
@@ -71,7 +62,7 @@ export const Form = (props) => {
         value={values.room}
         noOptionsText="Select a term to see locations"
       />
-      <div className={classes.buttonContainer}>
+      <div style={{ textAlign: "center" }}>
         <Button
           color="secondary"
           disabled={values.room === null}

--- a/src/forms/Schedule.jsx
+++ b/src/forms/Schedule.jsx
@@ -6,7 +6,6 @@ import {
   Slider,
   Typography,
 } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 import { Stack } from "@mui/system";
 import ChipAutoComplete from "components/ChipAutoComplete";
 import BasicSelect from "components/FormInputs/BasicSelect";
@@ -22,15 +21,7 @@ const sortObj = (objects) =>
     a.asString > b.asString ? 1 : b.asString > a.asString ? -1 : 0
   );
 
-const useStyles = makeStyles(() => ({
-  buttonContainer: {
-    textAlign: "center",
-  },
-}));
-
 export const Form = (props) => {
-  const classes = useStyles();
-
   const { values, handleChange, setValues } = useFormContext();
   const [courseOptions, setCourseOptions] = useState([]);
 
@@ -110,7 +101,7 @@ export const Form = (props) => {
           value={values.resultSize}
         />
       </div>
-      <div className={classes.buttonContainer}>
+      <div style={{ textAlign: "center" }}>
         <Button
           color="secondary"
           disabled={values.courses.length === 0}

--- a/src/layouts/ScheduleContainer.jsx
+++ b/src/layouts/ScheduleContainer.jsx
@@ -1,20 +1,17 @@
 import { CardContent, Checkbox, FormControlLabel, Grid, Typography } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 import AliasDesc from "components/AliasDesc";
 import Paging from "components/Paging";
 import Schedule from "components/Schedule";
 import { useState } from "react";
+import { styled } from "@mui/material";
 
-const useStyles = makeStyles({
-  content: {
-    alignItems: "center",
-    display: "flex",
-    justifyContent: "center",
-  },
-});
-
-const ScheduleContainer = ({ courseOrder, schedules, aliases, errorMessage }) => {
-  const classes = useStyles();
+const UnstyledScheduleContainer = ({
+  className,
+  courseOrder,
+  schedules,
+  aliases,
+  errorMessage,
+}) => {
   const [showInstructorNames, setShowInstructorNames] = useState(true);
   const [page, setPage] = useState(0);
 
@@ -34,8 +31,8 @@ const ScheduleContainer = ({ courseOrder, schedules, aliases, errorMessage }) =>
   };
 
   return (
-    <CardContent className={classes.content}>
-      <Grid container direction="column" className={classes.content}>
+    <CardContent className={className}>
+      <Grid container direction="column" className={className}>
         {schedules.length > 0 && (
           <Paging onChange={handlePageChange} pages={schedules.length} />
         )}
@@ -69,5 +66,11 @@ const ScheduleContainer = ({ courseOrder, schedules, aliases, errorMessage }) =>
     </CardContent>
   );
 };
+
+const ScheduleContainer = styled(UnstyledScheduleContainer)(() => ({
+  alignItems: "center",
+  display: "flex",
+  justifyContent: "center",
+}));
 
 export default ScheduleContainer;

--- a/src/layouts/UnderConstruction.jsx
+++ b/src/layouts/UnderConstruction.jsx
@@ -1,27 +1,15 @@
-import { AppBar, makeStyles, Toolbar, Typography } from "@mui/material";
-
-const useStyles = makeStyles({
-  root: {
-    flexGrow: 1,
-  },
-  appbar: {
-    position: "absolute",
-    color: "secondary",
-    alignItems: "center",
-  },
-  typography: {
-    flexGrow: 1,
-    textAlign: "center",
-  },
-});
+import { AppBar, Toolbar, Typography } from "@mui/material";
 
 export default function Footer() {
-  const classes = useStyles();
   return (
-    <div className={classes.root}>
+    <div style={{ flexGrow: 1 }}>
       <AppBar color="secondary">
         <Toolbar>
-          <Typography color="inherit" variant="h6" className={classes.typography}>
+          <Typography
+            color="inherit"
+            variant="h6"
+            sx={{ flexGrow: 1, textAlign: "center" }}
+          >
             Thank you for using schedubuddy. This website will go down on May 25, 2022.
           </Typography>
         </Toolbar>


### PR DESCRIPTION
Closes #43 

- Use [styled components](https://mui.com/material-ui/guides/interoperability/#styled-components) instead of makeStyles as makeStyles has been deprecated